### PR TITLE
Replace deprecated TNS hostnames with Mastercard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # TNSPaymentsGateway
 
-Wrapper around the TNS Payments REST API.
+Wrapper around the Mastercard Payment Gateway (formerly TNS Payments) REST API.
 
 ## Usage
 
-TNS API Documentation: https://secure.ap.tnspayments.com/api/documentation/apiDocumentation/rest-json/version/latest/api.html
+API Documentation: https://test-gateway.mastercard.com/api/documentation/apiDocumentation/rest-json/version/latest/api.html
 
 See spec/facade_spec.rb

--- a/bin/generate_reporting_columns.rb
+++ b/bin/generate_reporting_columns.rb
@@ -5,7 +5,7 @@
 require 'open-uri'
 require 'nokogiri'
 
-URL = "https://secure.ap.tnspayments.com/api/documentation/apiDocumentation/rest-json/version/latest/wadl.xml?locale=en_US"
+URL = "https://ap-gateway.mastercard.com/api/documentation/apiDocumentation/rest-json/version/latest/wadl.xml?locale=en_US"
 
 doc = open(URL) { |f| Nokogiri::XML(f) }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,7 +24,7 @@ end
 
 # rubocop:disable Metrics/LineLength
 def with_tokenizing_profile
-  with_env("AU_TNS_PAY_URL", "https://TESTEVHEROSTG02:e750f25acd207d168117d1050e6fbaf7@secure.ap.tnspayments.com") do
+  with_env("AU_TNS_PAY_URL", "https://TESTEVHEROSTG02:e750f25acd207d168117d1050e6fbaf7@ap-gateway.mastercard.com") do
     yield
   end
 end


### PR DESCRIPTION
Post the acquisition of TNSPay assets by Mastercard, *.tnspayments.com is deprecated in favour of *-gateway.mastercard.com, which will hit the same underlying host IP addresses.